### PR TITLE
表示データの管理方法を変更する

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# app
+[Here](https://generated-json-visualization.onrender.com/) is on Render deployed.
+
 # React + TypeScript + Vite
 
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,38 +15,23 @@ import { useDisplayData } from "./features/display-table/hooks/useDisplayData";
 import { useMemo } from "react";
 
 function App() {
-  const models = [
-    "baseline",
-    "ours1-series",
-    "ours1-parallel-mlp",
-    "ours1-parallel-res",
-  ];
-  const targetFiles = models.map((name) => `/sample-data/${name}.json`);
+  const modelNames = useMemo(
+    () => [
+      "baseline",
+      "ours1-series",
+      "ours1-parallel-res",
+      "ours1-parallel-mlp",
+    ],
+    [],
+  );
+  const [baseline, target, cmpr1, cmpr2] = modelNames;
 
-  const {
-    data: ours1seriesData,
-    loading,
-    pagination,
-    filter,
-    correct,
-  } = useDisplayData(targetFiles[1]);
-
-  const { data: baselineData } = useDisplayData(targetFiles[0]);
-  const { data: ours1parallelmlp } = useDisplayData(targetFiles[2]);
-  const { data: ours1parallelres } = useDisplayData(targetFiles[3]);
+  const { displayData, loading, pagination, filter, correct } =
+    useDisplayData(modelNames);
 
   const comparableDatas = useMemo(
-    () => [
-      {
-        name: "ours1-paralell-res",
-        data: ours1parallelres,
-      },
-      {
-        name: "ours1-parallel-mlp",
-        data: ours1parallelmlp,
-      },
-    ],
-    [ours1parallelmlp, ours1parallelres],
+    () => [displayData[cmpr1], displayData[cmpr2]],
+    [cmpr1, cmpr2, displayData],
   );
 
   return (
@@ -79,10 +64,23 @@ function App() {
           <Box marginInline="auto">
             <HStack gap="xl">
               <Flex gap="md" w="max-content" align="center">
-                <Text>hypothesis strategy is: </Text>
                 <Select
-                  value={filter.selectedLabel}
-                  onChange={filter.setSelectedLabel}
+                  value={filter.targetModelName}
+                  onChange={filter.onChangeTargetModelName}
+                  placeholderInOptions={false}
+                  defaultValue={filter.selectableModelNames[0]}
+                  w="sm"
+                >
+                  {filter.selectableModelNames.map((name) => (
+                    <Option key={name} value={name}>
+                      {name}
+                    </Option>
+                  ))}
+                </Select>
+                <Text>-</Text>
+                <Select
+                  value={filter.targetLabel}
+                  onChange={filter.onChangeTargetLabel}
                   placeholderInOptions={false}
                   placeholder="filter Strategy"
                   defaultValue={filter.selectableLabels[0]}
@@ -99,9 +97,9 @@ function App() {
                 <Checkbox
                   size="lg"
                   isChecked={correct.isCorrectedLabel}
-                  onChange={correct.toggle}
+                  onChange={correct.onChangeIsCorrectedLabel}
                 >
-                  correct strategy
+                  correct prediction
                 </Checkbox>
               </Box>
             </HStack>
@@ -117,8 +115,8 @@ function App() {
           borderRadius="xl"
         >
           <DisplayTable
-            targetData={ours1seriesData}
-            baselineData={baselineData}
+            targetData={displayData[target]}
+            baselineData={displayData[baseline]}
             comparisonDatas={comparableDatas}
             loading={loading}
           />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,9 @@ function App() {
   const modelNames = useMemo(
     () => [
       "baseline", // baseline
-      "ours1-series",  // target
+      "ours1-series", // target
+      "baseline-aft-ew", // baseline-re
+      "ours1-series-cog",
       "ours1-parallel-res",
       "ours1-parallel-mlp",
     ],
@@ -32,7 +34,6 @@ function App() {
   return (
     <>
       <Box w="full" h="full" bgColor="white">
-
         {/* header content */}
         <VStack
           w="full"
@@ -119,6 +120,7 @@ function App() {
               baselineData={displayData[baseline]}
               comparisonsData={comparisons.map((model) => displayData[model])}
               loading={loading}
+              targetModelName={filter.targetModelName}
             />
           ) : null}
         </Container>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -113,12 +113,14 @@ function App() {
           borderColor="blackAlpha.400"
           borderRadius="xl"
         >
-          <DisplayTable
-            targetData={displayData[target]}
-            baselineData={displayData[baseline]}
-            comparisonsData={comparisons.map((model) => displayData[model])}
-            loading={loading}
-          />
+          {displayData ? (
+            <DisplayTable
+              targetData={displayData[target]}
+              baselineData={displayData[baseline]}
+              comparisonsData={comparisons.map((model) => displayData[model])}
+              loading={loading}
+            />
+          ) : null}
         </Container>
       </Box>
     </>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,13 +15,13 @@ import { useDisplayData } from "./features/display-table/hooks/useDisplayData";
 import { useMemo } from "react";
 
 function App() {
-  const targetNames = [
+  const models = [
     "baseline",
     "ours1-series",
     "ours1-parallel-mlp",
     "ours1-parallel-res",
   ];
-  const targetFiles = targetNames.map((name) => `/sample-data/${name}.json`);
+  const targetFiles = models.map((name) => `/sample-data/${name}.json`);
 
   const {
     data: ours1seriesData,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,26 +17,23 @@ import { useMemo } from "react";
 function App() {
   const modelNames = useMemo(
     () => [
-      "baseline",
-      "ours1-series",
+      "baseline", // baseline
+      "ours1-series",  // target
       "ours1-parallel-res",
       "ours1-parallel-mlp",
     ],
     [],
   );
-  const [baseline, target, cmpr1, cmpr2] = modelNames;
+  const [baseline, target, ...comparisons] = modelNames;
 
   const { displayData, loading, pagination, filter, correct } =
     useDisplayData(modelNames);
 
-  const comparableDatas = useMemo(
-    () => [displayData[cmpr1], displayData[cmpr2]],
-    [cmpr1, cmpr2, displayData],
-  );
-
   return (
     <>
       <Box w="full" h="full" bgColor="white">
+
+        {/* header content */}
         <VStack
           w="full"
           paddingBlock="md"
@@ -105,6 +102,8 @@ function App() {
             </HStack>
           </Box>
         </VStack>
+
+        {/* main content */}
         <Container
           w="80%"
           minH="2xl"
@@ -117,7 +116,7 @@ function App() {
           <DisplayTable
             targetData={displayData[target]}
             baselineData={displayData[baseline]}
-            comparisonDatas={comparableDatas}
+            comparisonsData={comparisons.map((model) => displayData[model])}
             loading={loading}
           />
         </Container>

--- a/src/features/display-table/components/strategy-chart.tsx
+++ b/src/features/display-table/components/strategy-chart.tsx
@@ -34,10 +34,10 @@ function StrategyChart({
       probComparisons
         ? [
             { dataKey: "reference", color: "gray.500" },
-            { dataKey: probComparisons[1].name, color: "cyan.100" },
-            { dataKey: probComparisons[0].name, color: "violet.300" },
             { dataKey: "baseline", color: "red.500" },
             { dataKey: "ours1", color: "blue.500" },
+            { dataKey: probComparisons[0].name, color: "violet.300" },
+            { dataKey: probComparisons[1].name, color: "cyan.100" },
           ]
         : [],
     [probComparisons],
@@ -71,24 +71,10 @@ function StrategyChart({
 
   return (
     <>
-      {/* <BarChart
-        data={processedData}
-        series={series}
-        dataKey="name"
-        size="full"
-        valueFormatter={(value) => `${(value * 100).toFixed(2)}`}
-        unit="%"
-        withLegend
-        legendProps={{ verticalAlign: "bottom", justifyContent: "center" }}
-        tooltipAnimationDuration={300}
-        tooltipProps={{ position: { x: 900, y: 0 } }}
-      /> */}
-
       <AreaChart
         data={processedData}
         series={series}
         dataKey="name"
-        // curveType="linear"
         unit="%"
       />
     </>

--- a/src/features/display-table/components/strategy-chart.tsx
+++ b/src/features/display-table/components/strategy-chart.tsx
@@ -84,9 +84,6 @@ function StrategyChart({
         : null;
     });
 
-    console.log("strategy-chart");
-    console.log(result);
-
     return result;
   }, [baselineData, probComparisons, data, labels, referenceStrategyIdx]);
 

--- a/src/features/display-table/components/strategy-chart.tsx
+++ b/src/features/display-table/components/strategy-chart.tsx
@@ -37,10 +37,10 @@ function StrategyChart({
 
   const series: AreaProps[] = useMemo(() => {
     const dataColors = [
+      "pink.300", // baseline-re
       "sky.500", // ours1-series-cog
       "violet.300", // ours1-parallel-res
       "cyan.100", // ours1-parallel-mlp
-      "pink.300", // baseline-re
     ];
 
     const comparisonsSeries: AreaProps[] = probComparisons

--- a/src/features/display-table/display-table.tsx
+++ b/src/features/display-table/display-table.tsx
@@ -10,26 +10,26 @@ import {
   Divider,
   Grid,
   GridItem,
-  NativeTable,
+  // NativeTable,
   Skeleton,
-  TableContainer,
+  // TableContainer,
   Tag,
-  Tbody,
-  Td,
+  // Tbody,
+  // Td,
   Text,
-  Th,
-  Thead,
-  Tr,
+  // Th,
+  // Thead,
+  // Tr,
   VStack,
 } from "@yamada-ui/react";
-import { Dialogue } from "./hooks/useDisplayData";
+import { ModelData } from "./hooks/useDisplayData";
 import { StrategyChart } from "./components";
 import { useMemo } from "react";
 
 type DisplayTableProps = {
-  targetData: Dialogue[] | undefined;
-  baselineData: Dialogue[] | undefined;
-  comparisonDatas: Array<{ name: string; data: Dialogue[] | undefined }>;
+  targetData: ModelData;
+  baselineData: ModelData;
+  comparisonDatas: ModelData[];
   loading?: boolean;
 };
 function DisplayTable({
@@ -40,7 +40,6 @@ function DisplayTable({
 }: DisplayTableProps) {
   const labels = useMemo(
     () => [
-      /* 不明なラベル： "[Reflection of Feelings]", "[Self-disclosure]", "[Information]" */
       "[Question]",
       "[Reflection of feelings]",
       "[Information]",
@@ -58,10 +57,9 @@ function DisplayTable({
       {loading && <Skeleton h="xl" />}
       <VStack gap="3xl">
         {!loading &&
-          targetData &&
-          targetData.map((data, corpusIdx) => (
+          targetData.data.map((dialogue, corpusIdx) => (
             <Container
-              key={data.id}
+              key={dialogue.id}
               border="1px solid"
               borderColor="blackAlpha.400"
               borderRadius="xl"
@@ -72,10 +70,10 @@ function DisplayTable({
                   <Text as="h2" fontSize="xl" letterSpacing="wider">
                     <Text as="span" mr="md">
                       <Tag variant="outline" size="lg" colorScheme="neutral">
-                        {data.id}
+                        {dialogue.id}
                       </Tag>
                     </Text>
-                    {data.situation}
+                    {dialogue.situation}
                   </Text>
                 </Box>
 
@@ -98,7 +96,7 @@ function DisplayTable({
                           marginInline="auto"
                           divider={<Divider color="blackAlpha.300" />}
                         >
-                          {data.conversations.map((conv, idx) => (
+                          {dialogue.conversations.map((conv, idx) => (
                             <Grid
                               key={conv.utterances + idx}
                               templateColumns="min-content min-content 1fr"
@@ -154,11 +152,13 @@ function DisplayTable({
                           <Text fontSize="lg">reference</Text>
                         </GridItem>
                         <GridItem w="18rem">
-                          <Text fontSize="lg">{data.reference.strategy}</Text>
+                          <Text fontSize="lg">
+                            {dialogue.reference.strategy}
+                          </Text>
                         </GridItem>
                         <GridItem>
                           <Text fontSize="xl" letterSpacing="wider">
-                            {data.reference.response}
+                            {dialogue.reference.response}
                           </Text>
                         </GridItem>
                       </Grid>
@@ -174,14 +174,12 @@ function DisplayTable({
                         </GridItem>
                         <GridItem w="18rem">
                           <Text fontSize="lg">
-                            {baselineData &&
-                              baselineData[corpusIdx].hypothesis.strategy}
+                            {baselineData.data[corpusIdx].hypothesis.strategy}
                           </Text>
                         </GridItem>
                         <GridItem>
                           <Text fontSize="xl" letterSpacing="wider">
-                            {baselineData &&
-                              baselineData[corpusIdx].hypothesis.response}
+                            {baselineData.data[corpusIdx].hypothesis.response}
                           </Text>
                         </GridItem>
                       </Grid>
@@ -196,38 +194,40 @@ function DisplayTable({
                           <Text fontSize="lg">ours1-series</Text>
                         </GridItem>
                         <GridItem w="18rem">
-                          <Text fontSize="lg">{data.hypothesis.strategy}</Text>
+                          <Text fontSize="lg">
+                            {dialogue.hypothesis.strategy}
+                          </Text>
                         </GridItem>
                         <GridItem>
                           <Text fontSize="xl" letterSpacing="wider">
-                            {data.hypothesis.response}
+                            {dialogue.hypothesis.response}
                           </Text>
                         </GridItem>
                       </Grid>
 
-                      {comparisonDatas.map((item) => (
+                      {comparisonDatas.map((model) => (
                         <>
-                          <Divider key={item.name} />
+                          <Divider key={model.name} />
 
                           <Grid
-                            key={item.name}
+                            key={model.name}
                             templateColumns="min-content min-content 1fr"
                             alignItems="center"
                           >
                             <GridItem w="8rem">
-                              <Text fontSize="lg">{item.name}</Text>
+                              <Text fontSize="lg">{model.name}</Text>
                             </GridItem>
                             <GridItem w="18rem">
                               <Text fontSize="lg">
-                                {item && item.data
-                                  ? item.data[corpusIdx].hypothesis.strategy
+                                {model && model.data
+                                  ? model.data[corpusIdx].hypothesis.strategy
                                   : "no data"}
                               </Text>
                             </GridItem>
                             <GridItem>
                               <Text fontSize="xl" letterSpacing="wider">
-                                {item && item.data
-                                  ? item.data[corpusIdx].hypothesis.response
+                                {model && model.data
+                                  ? model.data[corpusIdx].hypothesis.response
                                   : "no data"}
                               </Text>
                             </GridItem>
@@ -249,47 +249,28 @@ function DisplayTable({
                         <VStack pt="md">
                           <Box>
                             <StrategyChart
-                              data={data.strategyProb.map((item) =>
-                                Number(`${(item * 100).toFixed(2)}`),
+                              data={dialogue.strategyProb.map((probValue) =>
+                                Number(`${(probValue * 100).toFixed(2)}`),
                               )}
-                              baselineData={
-                                baselineData
-                                  ? baselineData[corpusIdx].strategyProb.map(
-                                      (item) =>
-                                        Number(`${(item * 100).toFixed(2)}`),
-                                    )
-                                  : Array.from(new Array(8).fill(0.0))
-                              }
-                              probComparisons={
-                                comparisonDatas
-                                  ? comparisonDatas.map((item) =>
-                                      item.data
-                                        ? {
-                                            name: item.name,
-                                            data: item.data[
-                                              corpusIdx
-                                            ].strategyProb.map((item) =>
-                                              Number(
-                                                `${(item * 100).toFixed(2)}`,
-                                              ),
-                                            ),
-                                          }
-                                        : {
-                                            name: item.name,
-                                            data: Array.from(
-                                              new Array(8).fill(0.0),
-                                            ),
-                                          },
-                                    )
-                                  : undefined
-                              }
+                              baselineData={baselineData.data[
+                                corpusIdx
+                              ].strategyProb.map((probValue) =>
+                                Number(`${(probValue * 100).toFixed(2)}`),
+                              )}
+                              probComparisons={comparisonDatas.map((model) => ({
+                                name: model.name,
+                                data: model.data[corpusIdx].strategyProb.map(
+                                  (probValue) =>
+                                    Number(`${(probValue * 100).toFixed(2)}`),
+                                ),
+                              }))}
                               referenceStrategyIdx={labels.indexOf(
-                                data.reference.strategy,
+                                dialogue.reference.strategy,
                               )}
                             />
                           </Box>
 
-                          <TableContainer>
+                          {/* <TableContainer>
                             <NativeTable withBorder>
                               <Thead>
                                 <Tr>
@@ -311,7 +292,7 @@ function DisplayTable({
                                 </Tr>
                               </Tbody>
                             </NativeTable>
-                          </TableContainer>
+                          </TableContainer> */}
                         </VStack>
                       </AccordionPanel>
                     </AccordionItem>

--- a/src/features/display-table/display-table.tsx
+++ b/src/features/display-table/display-table.tsx
@@ -219,14 +219,14 @@ function DisplayTable({
                             </GridItem>
                             <GridItem w="18rem">
                               <Text fontSize="lg">
-                                {model && model.data
+                                {loading
                                   ? model.data[corpusIdx].hypothesis.strategy
                                   : "no data"}
                               </Text>
                             </GridItem>
                             <GridItem>
                               <Text fontSize="xl" letterSpacing="wider">
-                                {model && model.data
+                                {loading
                                   ? model.data[corpusIdx].hypothesis.response
                                   : "no data"}
                               </Text>
@@ -259,10 +259,14 @@ function DisplayTable({
                               )}
                               probComparisons={comparisonDatas.map((model) => ({
                                 name: model.name,
-                                data: model.data[corpusIdx].strategyProb.map(
-                                  (probValue) =>
-                                    Number(`${(probValue * 100).toFixed(2)}`),
-                                ),
+                                data: loading
+                                  ? model.data[corpusIdx].strategyProb.map(
+                                      (probValue) =>
+                                        Number(
+                                          `${(probValue * 100).toFixed(2)}`,
+                                        ),
+                                    )
+                                  : Array.from(new Array(8).fill(0.0)),
                               }))}
                               referenceStrategyIdx={labels.indexOf(
                                 dialogue.reference.strategy,

--- a/src/features/display-table/display-table.tsx
+++ b/src/features/display-table/display-table.tsx
@@ -10,32 +10,25 @@ import {
   Divider,
   Grid,
   GridItem,
-  // NativeTable,
   Skeleton,
-  // TableContainer,
   Tag,
-  // Tbody,
-  // Td,
   Text,
-  // Th,
-  // Thead,
-  // Tr,
   VStack,
 } from "@yamada-ui/react";
 import { ModelData } from "./hooks/useDisplayData";
 import { StrategyChart } from "./components";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 
 type DisplayTableProps = {
   targetData: ModelData;
   baselineData: ModelData;
-  comparisonDatas: ModelData[];
+  comparisonsData: ModelData[];
   loading?: boolean;
 };
 function DisplayTable({
   targetData,
   baselineData,
-  comparisonDatas,
+  comparisonsData,
   loading,
 }: DisplayTableProps) {
   const labels = useMemo(
@@ -51,6 +44,11 @@ function DisplayTable({
     ],
     [],
   );
+
+  useEffect(() => {
+    console.log("display-table");
+    console.log("data len: ", targetData.data.length)
+  }, [targetData.data.length])
 
   return (
     <>
@@ -143,7 +141,10 @@ function DisplayTable({
                     border="2px solid"
                     borderColor="blackAlpha.300"
                   >
-                    <VStack pl="sm">
+                    <VStack
+                      pl="sm"
+                      divider={<Divider color="blackAlpha.300" />}
+                    >
                       <Grid
                         templateColumns="min-content min-content 1fr"
                         alignItems="center"
@@ -162,8 +163,6 @@ function DisplayTable({
                           </Text>
                         </GridItem>
                       </Grid>
-
-                      <Divider color="blackAlpha.300" />
 
                       <Grid
                         templateColumns="min-content min-content 1fr"
@@ -184,8 +183,6 @@ function DisplayTable({
                         </GridItem>
                       </Grid>
 
-                      <Divider />
-
                       <Grid
                         templateColumns="min-content min-content 1fr"
                         alignItems="center"
@@ -205,34 +202,30 @@ function DisplayTable({
                         </GridItem>
                       </Grid>
 
-                      {comparisonDatas.map((model) => (
-                        <>
-                          <Divider key={model.name} />
-
-                          <Grid
-                            key={model.name}
-                            templateColumns="min-content min-content 1fr"
-                            alignItems="center"
-                          >
-                            <GridItem w="8rem">
-                              <Text fontSize="lg">{model.name}</Text>
-                            </GridItem>
-                            <GridItem w="18rem">
-                              <Text fontSize="lg">
-                                {loading
-                                  ? model.data[corpusIdx].hypothesis.strategy
-                                  : "no data"}
-                              </Text>
-                            </GridItem>
-                            <GridItem>
-                              <Text fontSize="xl" letterSpacing="wider">
-                                {loading
-                                  ? model.data[corpusIdx].hypothesis.response
-                                  : "no data"}
-                              </Text>
-                            </GridItem>
-                          </Grid>
-                        </>
+                      {comparisonsData.map((model, idx) => (
+                        <Grid
+                          key={model.name + idx}
+                          templateColumns="min-content min-content 1fr"
+                          alignItems="center"
+                        >
+                          <GridItem w="8rem">
+                            <Text fontSize="lg">{model.name}</Text>
+                          </GridItem>
+                          <GridItem w="18rem">
+                            <Text fontSize="lg">
+                              {!loading
+                                ? model.data[corpusIdx].hypothesis.strategy
+                                : "no data"}
+                            </Text>
+                          </GridItem>
+                          <GridItem key={model.name + idx}>
+                            <Text fontSize="xl" letterSpacing="wider">
+                              {!loading
+                                ? model.data[corpusIdx].hypothesis.response
+                                : "no data"}
+                            </Text>
+                          </GridItem>
+                        </Grid>
                       ))}
                     </VStack>
                   </Card>
@@ -248,55 +241,35 @@ function DisplayTable({
                       <AccordionPanel>
                         <VStack pt="md">
                           <Box>
-                            <StrategyChart
-                              data={dialogue.strategyProb.map((probValue) =>
-                                Number(`${(probValue * 100).toFixed(2)}`),
-                              )}
-                              baselineData={baselineData.data[
-                                corpusIdx
-                              ].strategyProb.map((probValue) =>
-                                Number(`${(probValue * 100).toFixed(2)}`),
-                              )}
-                              probComparisons={comparisonDatas.map((model) => ({
-                                name: model.name,
-                                data: loading
-                                  ? model.data[corpusIdx].strategyProb.map(
-                                      (probValue) =>
-                                        Number(
-                                          `${(probValue * 100).toFixed(2)}`,
-                                        ),
-                                    )
-                                  : Array.from(new Array(8).fill(0.0)),
-                              }))}
-                              referenceStrategyIdx={labels.indexOf(
-                                dialogue.reference.strategy,
-                              )}
-                            />
+                            {!loading ? (
+                              <StrategyChart
+                                data={dialogue.strategyProb.map((probValue) =>
+                                  Number(`${(probValue * 100).toFixed(2)}`),
+                                )}
+                                baselineData={baselineData.data[
+                                  corpusIdx
+                                ].strategyProb.map((probValue) =>
+                                  Number(`${(probValue * 100).toFixed(2)}`),
+                                )}
+                                probComparisons={comparisonsData.map(
+                                  (model) => ({
+                                    name: model.name,
+                                    data: !loading
+                                      ? model.data[corpusIdx].strategyProb.map(
+                                          (probValue) =>
+                                            Number(
+                                              `${(probValue * 100).toFixed(2)}`,
+                                            ),
+                                        )
+                                      : Array.from(new Array(8).fill(0.0)),
+                                  }),
+                                )}
+                                referenceStrategyIdx={labels.indexOf(
+                                  dialogue.reference.strategy,
+                                )}
+                              />
+                            ) : null}
                           </Box>
-
-                          {/* <TableContainer>
-                            <NativeTable withBorder>
-                              <Thead>
-                                <Tr>
-                                  {labels.map((label, idx) => (
-                                    <Th key={idx} textAlign="center">
-                                      {label}
-                                    </Th>
-                                  ))}
-                                </Tr>
-                              </Thead>
-
-                              <Tbody>
-                                <Tr>
-                                  {data.strategyProb.map((float, idx) => (
-                                    <Td key={idx} textAlign="center">
-                                      {(float * 100).toFixed(2)}%
-                                    </Td>
-                                  ))}
-                                </Tr>
-                              </Tbody>
-                            </NativeTable>
-                          </TableContainer> */}
                         </VStack>
                       </AccordionPanel>
                     </AccordionItem>

--- a/src/features/display-table/display-table.tsx
+++ b/src/features/display-table/display-table.tsx
@@ -22,14 +22,14 @@ import {
   Tr,
   VStack,
 } from "@yamada-ui/react";
-import { DisplayData } from "./hooks/useDisplayData";
+import { Dialogue } from "./hooks/useDisplayData";
 import { StrategyChart } from "./components";
 import { useMemo } from "react";
 
 type DisplayTableProps = {
-  targetData: DisplayData | undefined;
-  baselineData: DisplayData | undefined;
-  comparisonDatas: Array<{ name: string; data: DisplayData | undefined }>;
+  targetData: Dialogue[] | undefined;
+  baselineData: Dialogue[] | undefined;
+  comparisonDatas: Array<{ name: string; data: Dialogue[] | undefined }>;
   loading?: boolean;
 };
 function DisplayTable({

--- a/src/features/display-table/display-table.tsx
+++ b/src/features/display-table/display-table.tsx
@@ -17,7 +17,7 @@ import {
 } from "@yamada-ui/react";
 import { ModelData } from "./hooks/useDisplayData";
 import { StrategyChart } from "./components";
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 
 type DisplayTableProps = {
   targetData: ModelData;
@@ -44,11 +44,6 @@ function DisplayTable({
     ],
     [],
   );
-
-  useEffect(() => {
-    console.log("display-table");
-    console.log("data len: ", targetData.data.length)
-  }, [targetData.data.length])
 
   return (
     <>

--- a/src/features/display-table/display-table.tsx
+++ b/src/features/display-table/display-table.tsx
@@ -24,12 +24,14 @@ type DisplayTableProps = {
   baselineData: ModelData;
   comparisonsData: ModelData[];
   loading?: boolean;
+  targetModelName?: string;
 };
 function DisplayTable({
   targetData,
   baselineData,
   comparisonsData,
   loading,
+  targetModelName,
 }: DisplayTableProps) {
   const labels = useMemo(
     () => [
@@ -44,6 +46,11 @@ function DisplayTable({
     ],
     [],
   );
+
+  const [baselineRe, comparisons] = [
+    comparisonsData[0],
+    comparisonsData.slice(1),
+  ];
 
   return (
     <>
@@ -128,7 +135,7 @@ function DisplayTable({
                   </Accordion>
                 </Box>
 
-                {/* strategy */}
+                {/* prediction */}
                 <Box>
                   <Card
                     p="md"
@@ -164,7 +171,16 @@ function DisplayTable({
                         alignItems="center"
                       >
                         <GridItem w="8rem">
-                          <Text fontSize="lg">baseline</Text>
+                          <Text
+                            fontSize="lg"
+                            fontWeight={
+                              targetModelName === baselineData.name
+                                ? "bold"
+                                : undefined
+                            }
+                          >
+                            baseline
+                          </Text>
                         </GridItem>
                         <GridItem w="18rem">
                           <Text fontSize="lg">
@@ -183,7 +199,44 @@ function DisplayTable({
                         alignItems="center"
                       >
                         <GridItem w="8rem">
-                          <Text fontSize="lg">ours1-series</Text>
+                          <Text
+                            fontSize="lg"
+                            fontWeight={
+                              targetModelName === baselineRe.name
+                                ? "bold"
+                                : undefined
+                            }
+                          >
+                            baseline-re
+                          </Text>
+                        </GridItem>
+                        <GridItem w="18rem">
+                          <Text fontSize="lg">
+                            {baselineRe.data[corpusIdx].hypothesis.strategy}
+                          </Text>
+                        </GridItem>
+                        <GridItem>
+                          <Text fontSize="xl" letterSpacing="wider">
+                            {baselineRe.data[corpusIdx].hypothesis.response}
+                          </Text>
+                        </GridItem>
+                      </Grid>
+
+                      <Grid
+                        templateColumns="min-content min-content 1fr"
+                        alignItems="center"
+                      >
+                        <GridItem w="8rem">
+                          <Text
+                            fontSize="lg"
+                            fontWeight={
+                              targetModelName === targetData.name
+                                ? "bold"
+                                : undefined
+                            }
+                          >
+                            ours1-series
+                          </Text>
                         </GridItem>
                         <GridItem w="18rem">
                           <Text fontSize="lg">
@@ -197,14 +250,23 @@ function DisplayTable({
                         </GridItem>
                       </Grid>
 
-                      {comparisonsData.map((model, idx) => (
+                      {comparisons.map((model: ModelData, idx) => (
                         <Grid
                           key={model.name + idx}
                           templateColumns="min-content min-content 1fr"
                           alignItems="center"
                         >
                           <GridItem w="8rem">
-                            <Text fontSize="lg">{model.name}</Text>
+                            <Text
+                              fontSize="lg"
+                              fontWeight={
+                                targetModelName === model.name
+                                  ? "bold"
+                                  : undefined
+                              }
+                            >
+                              {model.name}
+                            </Text>
                           </GridItem>
                           <GridItem w="18rem">
                             <Text fontSize="lg">

--- a/src/features/display-table/hooks/useDisplayData.ts
+++ b/src/features/display-table/hooks/useDisplayData.ts
@@ -126,6 +126,8 @@ function useDisplayData(models: string[]) {
 
   /* update filteredData when dependencies changed */
   useEffect(() => {
+    console.log("filtering");
+
     if (!isLoading) {
       /* filtering by target label */
       const tmpTargetDialogueIds: Array<Dialogue["id"]> = [];
@@ -161,6 +163,8 @@ function useDisplayData(models: string[]) {
         Math.ceil(newDataMap[targetModelName].data.length / displayAmount),
       );
       setFilteredData(newDataMap);
+
+      console.log("filtering end")
     }
   }, [
     displayData,
@@ -174,6 +178,8 @@ function useDisplayData(models: string[]) {
 
   /* handle changing page */
   useEffect(() => {
+    console.log("changing page");
+
     if (!isLoading) {
       // data slice for one page amount
       let pageNum: number;
@@ -194,6 +200,8 @@ function useDisplayData(models: string[]) {
         return acc;
       }, {} as DisplayDataMap);
       setFilteredDisplayData(newDataMap);
+      
+      console.log("changing page end")
     }
   }, [displayAmount, filteredData, isLoading, maxPage, page]);
 

--- a/src/features/display-table/hooks/useDisplayData.ts
+++ b/src/features/display-table/hooks/useDisplayData.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import { useBoolean } from "@yamada-ui/react";
 import { useEffect, useMemo, useState } from "react";
 import useSWR from "swr";
@@ -59,15 +60,35 @@ const useResultData = (models: string[]): UseResultDataProps => {
   const files = models.map((model) => `/sample-data/${model}.json`);
   const { data: jsonData, error, isLoading } = useSWR(files, fetcher);
 
-  const dataMap: DisplayDataMap = {};
+  const dataMap: DisplayDataMap = useMemo(() => ({}), []);
   models.forEach((model, idx) => {
     dataMap[model] = {
       name: model,
-      data: jsonData ? jsonData[idx].slice(0, 15) : ([] as Dialogue[]),
+      data: jsonData ? jsonData[idx] : ([] as Dialogue[])
+      // data: jsonData ? jsonData[idx].slice(0, 21) : ([] as Dialogue[]),
     };
   });
 
-  return { data: dataMap, error, isLoading };
+  const [displayData, setDisplayData] = useState<DisplayDataMap>(dataMap);
+
+  useEffect(() => {
+    if (!isLoading) {
+      const newDataMap: DisplayDataMap = {};
+      models.forEach((model, idx) => {
+        newDataMap[model] = {
+          name: model,
+          data: jsonData ? jsonData[idx] : ([] as Dialogue[]),
+          // data: jsonData ? jsonData[idx].slice(0, 21) : ([] as Dialogue[]),
+        };
+      });
+
+      setDisplayData(newDataMap);
+      console.log("load: ", displayData);
+      console.log("\n\n");
+    }
+  }, [isLoading, jsonData, models]);
+
+  return { data: displayData, error, isLoading };
 };
 
 /* 表示用データを提供する */
@@ -75,32 +96,24 @@ function useDisplayData(models: string[]) {
   const { data: displayData, isLoading, error } = useResultData(models);
 
   /* filtering */
-  const [filterdDisplayData, setFilteredDisplayData] =
-    useState<DisplayDataMap>(displayData);
+  const [filterdDisplayData, setFilteredDisplayData] = useState<DisplayDataMap>(
+    { ...displayData },
+  );
   const [targetModelName, setTargetModelName] = useState<ModelData["name"]>(
-    displayData[models[0]].name,
+    models[0],
   );
   const [targetLabel, setTargetLabel] = useState<Selection>("any") as [
     Selection,
     (value: string) => void,
   ];
   const [isCorrectedLabel, { toggle }] = useBoolean(false); // filter correct strategy
-  const [targetDialogueIds, setTmpTargetDialogueIds] = useState<
-    Array<Dialogue["id"]>
-  >([]);
 
   /* pagination */
-  const displayAmount = 10;
+  const displayAmount = useMemo(() => 10, []);
   const [page, onChange] = useState<number>(1);
-  const [maxPage, setMaxPage] = useState<number>(
-    filterdDisplayData && filterdDisplayData[targetModelName]
-      ? Math.ceil(
-          filterdDisplayData[targetModelName].data.length / displayAmount,
-        )
-      : 1,
-  );
+  const [maxPage, setMaxPage] = useState<number>(1);
 
-  const selectableModelNames: string[] = models;
+  const selectableModelNames: string[] = useMemo(() => models, [models]);
   const selectableLabels: string[] = useMemo(
     () => [
       "any",
@@ -116,57 +129,121 @@ function useDisplayData(models: string[]) {
     [],
   );
 
+  // const handleChangeModelName = useCallback(() => {
+  //   handleFilteringData();
+  //   // handleChangePage();
+  //   return setTargetModelName;
+  // }, [handleFilteringData]);
+
+  // const handleChangeLabel = useCallback(() => {
+  //   handleFilteringData();
+  //   handleChangePage();
+  //   return setTargetLabel;
+  // }, [handleFilteringData]);
+
   /* update filteredData when dependencies changed */
   useEffect(() => {
-    /* filtering by target label */
-    const tmpTargetDialogueIds: Array<Dialogue["id"]> = [];
+    console.log("filtering start");
 
-    // search target dialogue ids (hyp.label === targetLabel) in target model
-    displayData[targetModelName].data.forEach((dialogue: Dialogue) => {
-      const isTargetLabel =
-        targetLabel === "any"
-          ? true
-          : targetLabel === dialogue.hypothesis.strategy;
-      const isCorrect =
-        isCorrectedLabel === true
+    if (!isLoading) {
+      /* filtering by target label */
+      const tmpTargetDialogueIds: Array<Dialogue["id"]> = [];
+
+      // console.log("display data: ", displayData);
+
+      // search target dialogue ids (hyp.label === targetLabel) in target model
+      displayData[targetModelName].data.forEach((dialogue: Dialogue) => {
+        const isTargetLabel =
+          targetLabel === "any" || targetLabel === dialogue.hypothesis.strategy;
+        const isCorrect = isCorrectedLabel
           ? dialogue.hypothesis.strategy === dialogue.reference.strategy
           : true;
 
-      // push intended label id
-      isTargetLabel && isCorrect
-        ? tmpTargetDialogueIds.push(dialogue.id)
-        : null;
-    });
-    setTmpTargetDialogueIds(() => tmpTargetDialogueIds);
+        // push intended label id
+        isTargetLabel && isCorrect
+          ? tmpTargetDialogueIds.push(dialogue.id)
+          : null;
 
-    // filter data in order to match tmpTargetDialogueIds
-    //   and store new display data have target dialogue
-    const newDataMap: DisplayDataMap = { ...displayData };
-    Object.keys(displayData).forEach((modelName: string) => {
-      newDataMap[modelName].data = displayData[modelName].data.filter(
-        (dialogue: Dialogue) => tmpTargetDialogueIds.includes(dialogue.id),
-      );
-    });
-    setFilteredDisplayData(() => ({ ...newDataMap }));
-  }, [displayData, isCorrectedLabel, targetLabel, targetModelName]);
-
-  // data filtering後にペジネーション状態を更新する
-  useEffect(() => {
-    // pagination proccess
-    setMaxPage(() => Math.ceil(targetDialogueIds.length / displayAmount));
-    // data proccess
-    setFilteredDisplayData((prev) => {
-      // filtered?.slice(displayAmount * (page - 1), displayAmount * page),
-      const newDataMap = { ...prev };
-      Object.keys(prev).forEach((modelName) => {
-        newDataMap[modelName].data = prev[modelName].data.slice(
-          displayAmount * (page - 1),
-          displayAmount * page,
-        );
+        // console.log("isCorrect: ", isCorrect);
+        // console.log("isTargetLabel: ", isTargetLabel);
       });
-      return newDataMap;
-    });
-  }, [page, targetDialogueIds.length]);
+      // console.log("tmp target dialogues: ", tmpTargetDialogueIds);
+      // setTargetDialogueIds(tmpTargetDialogueIds);
+
+      // filter data in order to match tmpTargetDialogueIds
+      //   and store new display data have target dialogue
+      // console.log("display data: ", displayData);
+      // const newDataMap: DisplayDataMap = { ...displayData };
+      // Object.keys(displayData).forEach((modelName: string) => {
+      //   newDataMap[modelName].data = displayData[modelName].data.filter(
+      //     (dialogue: Dialogue) => tmpTargetDialogueIds.includes(dialogue.id),
+      //   );
+      // });
+      const newDataMap: DisplayDataMap = Object.keys(displayData).reduce(
+        (acc, modelName) => {
+          acc[modelName] = {
+            ...displayData[modelName],
+            data: displayData[modelName].data.filter((dialogue: Dialogue) =>
+              tmpTargetDialogueIds.includes(dialogue.id),
+            ),
+          };
+          return acc;
+        },
+        {} as DisplayDataMap,
+      );
+      setFilteredDisplayData(() => ({ ...newDataMap }));
+      // console.log("display data: ", displayData);
+      // console.log("newDatamap", newDataMap);
+      // console.log(targetModelName, targetLabel);
+
+      console.log("filtering end");
+      console.log("\n\n");
+    }
+  }, [displayData, isCorrectedLabel, isLoading, targetLabel, targetModelName]);
+
+  /* handle changing page */
+  useEffect(() => {
+    console.log("pagination start");
+    // console.log("bef data: ", displayData);
+
+    if (!isLoading) {
+      // console.log("bef data: ", displayData);
+
+      // pagination max length
+      setMaxPage(() =>
+        Math.ceil(displayData[targetModelName].data.length / displayAmount),
+      );
+
+      // console.log(Object.keys(filterdDisplayData));
+      // console.log(
+      //   "max page: ",
+      //   Math.ceil(displayData[targetModelName].data.length / displayAmount),
+      // );
+      // console.log("page: ", page);
+      // console.log(
+      //   `in filtering, ${displayAmount * (page - 1)} ~ ${displayAmount * page}`,
+      // );
+      // console.log("bef data: ", displayData);
+
+      // data slice for one page amount
+      const newDataMap = Object.keys(displayData).reduce((acc, modelName) => {
+        acc[modelName] = {
+          ...displayData[modelName],
+          data: displayData[modelName].data.slice(
+            displayAmount * (page - 1),
+            displayAmount * page,
+          ),
+        };
+        return acc;
+      }, {} as DisplayDataMap);
+      setFilteredDisplayData({ ...newDataMap });
+
+      // console.log("new data: ", newDataMap);
+
+      console.log("pagination end");
+      console.log("\n\n");
+    }
+  }, [displayAmount, displayData, isLoading, page, targetModelName]);
 
   return {
     displayData: filterdDisplayData,


### PR DESCRIPTION
カスタムフックの入出力を変更。

モデル名の配列を受け取ると、そのモデルファイルを探しに行き、取得したデータを整形してstateの配列形式で返却する。
全てのデータはstateで管理され、ターゲットモデルやラベルの変更、ページ移動などによって表示用データが変化する。